### PR TITLE
Update all b_rates prior to changing the fee mode 

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -150,6 +150,9 @@ impl FeeVault {
             panic_with_error!(&e, FeeVaultError::InvalidFeeModeValue);
         }
 
+        // Accrue interest for all reserves prior to updating the fee-mode, to avoid any retroactive effect
+        reserve_vault::accrue_interest_for_all_reserves(&e);
+
         storage::set_fee_mode(
             &e,
             storage::FeeMode {
@@ -200,6 +203,8 @@ impl FeeVault {
                     accrued_fees: 0,
                 },
             );
+
+            storage::add_reserve_to_reserves(&e, reserve_address.clone());
             FeeVaultEvents::new_reserve_vault(&e, &reserve_address);
         }
     }

--- a/src/reserve_vault.rs
+++ b/src/reserve_vault.rs
@@ -228,6 +228,16 @@ pub fn claim_fees(e: &Env, reserve: &Address) -> (i128, i128) {
     (b_tokens_amount, underlying_amount)
 }
 
+/// Accrues interest and updates the b_rate for all reserves
+pub fn accrue_interest_for_all_reserves(e: &Env) {
+    let reserves = storage::get_reserves(e);
+
+    for reserve in reserves {
+        let updated_vault = get_reserve_vault_updated(e, &reserve);
+        storage::set_reserve_vault(e, &reserve, &updated_vault);
+    }
+}
+
 #[cfg(test)]
 mod generic_tests {
     use super::*;


### PR DESCRIPTION
- Store all the supported reserves in the persistent storage, under the `Reserves` key
- Update `add_reserve_vault` to also add the `reserve_address` in the reserves vector
- Update the `b_rate` for all reserves prior to changing the fee mode